### PR TITLE
Homebridge 2.0 Compatibility

### DIFF
--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -24,7 +24,7 @@ export class Service {
         // Checks if the service has been cached
         let hapService: HapService|null = null;
         if (this.subType != null) {
-            hapService = this.accessory.platformAccessory.getServiceByUUIDAndSubType(<WithUUID<typeof HapService>>this.type, this.subType) || null;
+            hapService = this.accessory.platformAccessory.getServiceById(<WithUUID<typeof HapService>>this.type, this.subType) || null;
         } else {
             hapService = this.accessory.platformAccessory.getService(<WithUUID<typeof HapService>>this.type) || null;
         }


### PR DESCRIPTION
The only issue I saw when using a plugin that relies on Homebridge-framework ([homebridge-dummy-radio-switch](https://github.com/lukasroegner/homebridge-dummy-radio-switch)) was an error in `lib/service.ts` because `Accessory.getServiceByUUIDAndSubType()` has changed to `Accessory.getServiceById()`. There's no guarantee this is the only issue, but it's the only one I encountered.

Should hopefully fix #4.